### PR TITLE
Char operations must transfer character wide units

### DIFF
--- a/yoda
+++ b/yoda
@@ -2258,13 +2258,13 @@ semicolon
 inline
 
 colon 'c@'
-   put 'm[s[sp]]&255'
+   put 'm[s[sp]]'
 semicolon
 inline
 
 
 colon 'c!'
-   code '((m[s[sp--]]=s[sp-1]&255))'
+   code '((m[s[sp--]]=s[sp-1]))'
    code '((sp--))'
 semicolon
 inline
@@ -2836,8 +2836,8 @@ primitive 'abs'            '((s[sp]&msb))&&((s[sp]=(-s[sp]&true)))'  # ( n -- u 
 # ----- memory -------------------------------------------
 
 primitive '@'              '((s[sp]=m[s[sp]]))'                      # ( a -- x )
-primitive 'c,'             '((m[dp++]=s[sp--]&255))'                 # ( c -- )
-primitive 'count'          '((s[++sp]=m[s[sp]++]&255))'              # ( a -- a+1 c )
+primitive 'c,'             '((m[dp++]=s[sp--]))'                     # ( c -- )
+primitive 'count'          '((s[++sp]=m[s[sp]++]))'                  # ( a -- a+1 c )
 primitive 'skim'           '((s[++sp]=m[s[sp]++]))'                  # ( a -- a+cell x )
 primitive '<-'             '((m[s[sp--]]=s[sp--]))'                  # ( a x -- )
 primitive 'here$'          '((s[++sp]=sdp))'                         # ( -- u )


### PR DESCRIPTION
The standard operations on characters like `fill`, `c!`, `c,`, `c@` shall transfer all bits of a character unit according to its size. Since a character size is 1 address unit, and an address unit width is 64 bits, then these operations shall transfer 64 bits too.

`fill` meets this requirement, but other three operation transferred only 8 bits before that.

It fixes GH-22